### PR TITLE
Missing unused attr

### DIFF
--- a/src/test-api.c
+++ b/src/test-api.c
@@ -41,7 +41,7 @@ static void test_api(void) {
         free(argv);
 }
 
-int main(int argc, char **argv) {
+int main(void) {
         test_api();
         return 0;
 }

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -137,7 +137,7 @@ static void test_parse(void) {
         free(argv);
 }
 
-int main(int argc, char *argv[]) {
+int main(void) {
         test_quote();
         test_unquote();
         test_reverse();

--- a/src/test-private.c
+++ b/src/test-private.c
@@ -380,7 +380,7 @@ static void test_unquote_double(void) {
         c_assert(!memcmp(buf, "fo\"obar", strlen(string) - 3));
 }
 
-int main(int argc, char *argv[]) {
+int main(void) {
         test_append_str();
         test_append_char();
         test_skip_str();

--- a/src/test-reference.c
+++ b/src/test-reference.c
@@ -114,7 +114,7 @@ static void test_parse(void) {
         test_parse_one("/usr/libexec/at-spi-bus-launcher");
 }
 
-int main(int argc, char *argv[]) {
+int main(void) {
         test_quote();
         test_unquote();
         test_parse();


### PR DESCRIPTION
When configuring the build dir with meson -Dwarning_level=2 builddir (or when doing that in a superproject) some warnings are thrown for the unused variables in the test sources; I fixed this also for c-stdaux and updated the submodule correspondingly